### PR TITLE
Add simple IEnumerable extension for topological sort

### DIFF
--- a/TopologicalSorting/IEnumerableExtensions.cs
+++ b/TopologicalSorting/IEnumerableExtensions.cs
@@ -2,6 +2,9 @@
 
 namespace TopologicalSorting
 {
+    using System;
+    using System.Linq;
+
     /// <summary>
     /// Extensions to IEnumerable
     /// </summary>
@@ -134,6 +137,34 @@ namespace TopologicalSorting
                 follower.After(predecessors);
 
             return followers;
+        }
+
+
+
+        public static IEnumerable<T> TopologicalSort<T>(this IEnumerable<T> collection, Func<T, T, bool> isRequiredFor)
+        {
+            var graph = new DependencyGraph<T>();
+            var vertices = collection.Select(o => new OrderedProcess<T>(graph, o)).ToList();
+            foreach (var v1 in vertices)
+            {
+                foreach (var v2 in vertices)
+                {
+                    if (isRequiredFor(v1.Value, v2.Value))
+                    {
+                        v1.Before(v2);
+                    }
+                }
+            }
+
+            var sortEnumerator = graph.CalculateSort().GetEnumerator();
+            var orderedResults = new List<T>();
+
+            while (sortEnumerator.MoveNext())
+            {
+                orderedResults.Add((T)sortEnumerator.Current);
+            }
+
+            return orderedResults;
         }
     }
 }

--- a/TopologicalSorting/IEnumerableExtensions.cs
+++ b/TopologicalSorting/IEnumerableExtensions.cs
@@ -143,6 +143,11 @@ namespace TopologicalSorting
 
         public static IEnumerable<T> TopologicalSort<T>(this IEnumerable<T> collection, Func<T, T, bool> isRequiredFor)
         {
+            if (!collection.Any())
+            {
+                return new List<T>();
+            }
+
             var graph = new DependencyGraph<T>();
             var vertices = collection.Select(o => new OrderedProcess<T>(graph, o)).ToList();
             foreach (var v1 in vertices)


### PR DESCRIPTION
In my project, I have to order a list of objects by dependencies, in order to make my code clean from complicated and not related terms such as graphs, ordered processes, etc. I added this function that enables the novice user to use the one of the basic capabilities of this library very easily.